### PR TITLE
Lab4 - Interrupt binary semaphore

### DIFF
--- a/LABS/4/readme.txt
+++ b/LABS/4/readme.txt
@@ -1,0 +1,8 @@
+SID:014529138
+LAB4-Interrupt and Binary Semaphores
+
+Part0 and Part1 are commented. Part2 is extended.
+The lab serves ISR - Binary semaphore usage as well as ISR - user defined callback usage.
+The lab supports multi-port interrupt functionality.	
+
+

--- a/projects/lpc40xx_freertos/interrupt_vector_table.c
+++ b/projects/lpc40xx_freertos/interrupt_vector_table.c
@@ -24,6 +24,7 @@ extern void lpc_peripheral__interrupt_dispatcher(void);
 
 static void halt(void);
 static void isr_hard_fault(void);
+void gpio_interrupt(void);
 
 /**
  * This is non static otherwise compiler optimizes this function away but it is used in assembly code
@@ -93,7 +94,7 @@ __attribute__((section(".interrupt_vector_table"))) const function__void_f inter
     lpc_peripheral__interrupt_dispatcher, // 51 UART 4
     lpc_peripheral__interrupt_dispatcher, // 52 SSP 2
     lpc_peripheral__interrupt_dispatcher, // 53 LCD
-    lpc_peripheral__interrupt_dispatcher, // 54 GPIO Interrupt
+    gpio_interrupt,                       // 54 GPIO Interrupt
     lpc_peripheral__interrupt_dispatcher, // 55 PWM 0
     lpc_peripheral__interrupt_dispatcher, // 56 EEPROM
 };

--- a/projects/lpc40xx_freertos/interrupt_vector_table.c
+++ b/projects/lpc40xx_freertos/interrupt_vector_table.c
@@ -24,7 +24,6 @@ extern void lpc_peripheral__interrupt_dispatcher(void);
 
 static void halt(void);
 static void isr_hard_fault(void);
-void gpio_interrupt(void);
 
 /**
  * This is non static otherwise compiler optimizes this function away but it is used in assembly code
@@ -94,7 +93,7 @@ __attribute__((section(".interrupt_vector_table"))) const function__void_f inter
     lpc_peripheral__interrupt_dispatcher, // 51 UART 4
     lpc_peripheral__interrupt_dispatcher, // 52 SSP 2
     lpc_peripheral__interrupt_dispatcher, // 53 LCD
-    gpio_interrupt,                       // 54 GPIO Interrupt
+    lpc_peripheral__interrupt_dispatcher, // 54 GPIO Interrupt
     lpc_peripheral__interrupt_dispatcher, // 55 PWM 0
     lpc_peripheral__interrupt_dispatcher, // 56 EEPROM
 };

--- a/projects/lpc40xx_freertos/l3_drivers/gpio_isr.h
+++ b/projects/lpc40xx_freertos/l3_drivers/gpio_isr.h
@@ -3,7 +3,7 @@
 
 #include "gpio.h"
 #include "lpc40xx.h"
-//#include <stdio.h>
+#include <stdio.h>
 typedef enum {
   GPIO_INTR__FALLING_EDGE,
   GPIO_INTR__RISING_EDGE,

--- a/projects/lpc40xx_freertos/l3_drivers/gpio_isr.h
+++ b/projects/lpc40xx_freertos/l3_drivers/gpio_isr.h
@@ -2,19 +2,21 @@
 #pragma once
 
 #include "gpio.h"
-
+#include "lpc40xx.h"
+//#include <stdio.h>
 typedef enum {
   GPIO_INTR__FALLING_EDGE,
   GPIO_INTR__RISING_EDGE,
 } gpio_interrupt_e;
 
-typedef enum { PORT0, PORT2 } gpio_port_e;
+void user_isr(void);
+void sem_isr(void);
 
 // Function pointer type (demonstrated later in the code sample)
 typedef void (*function_pointer_t)(void);
 
 // Allow the user to attach their callbacks
-void gpio__attach_interrupt(gpio_port_e port, uint32_t pin, gpio_interrupt_e interrupt_type,
+void gpio__attach_interrupt(gpio__port_e port, uint32_t pin, gpio_interrupt_e interrupt_type,
                             function_pointer_t callback);
 
 // Our main() should configure interrupts to invoke this dispatcher where we will invoke user attached callbacks

--- a/projects/lpc40xx_freertos/l3_drivers/gpio_isr.h
+++ b/projects/lpc40xx_freertos/l3_drivers/gpio_isr.h
@@ -1,0 +1,22 @@
+// @file gpio_isr.h
+#pragma once
+
+#include "gpio.h"
+
+typedef enum {
+  GPIO_INTR__FALLING_EDGE,
+  GPIO_INTR__RISING_EDGE,
+} gpio_interrupt_e;
+
+typedef enum { PORT0, PORT2 } gpio_port_e;
+
+// Function pointer type (demonstrated later in the code sample)
+typedef void (*function_pointer_t)(void);
+
+// Allow the user to attach their callbacks
+void gpio__attach_interrupt(gpio_port_e port, uint32_t pin, gpio_interrupt_e interrupt_type,
+                            function_pointer_t callback);
+
+// Our main() should configure interrupts to invoke this dispatcher where we will invoke user attached callbacks
+// You can hijack 'interrupt_vector_table.c' or use API at lpc_peripherals.h
+void gpio__interrupt_dispatcher(void);

--- a/projects/lpc40xx_freertos/l3_drivers/sources/gpio_isr.c
+++ b/projects/lpc40xx_freertos/l3_drivers/sources/gpio_isr.c
@@ -2,7 +2,7 @@
 #include "gpio_isr.h"
 
 // Note: You may want another separate array for falling vs. rising edge callbacks
-static function_pointer_t gpio_callbacks[2] = {sem_isr, user_isr};
+static function_pointer_t gpio_callbacks[] = {sem_isr, user_isr};
 static void clear_pin_interrupt(gpio__port_e port, int interrupt_pin);
 static int read_pin_interrupt(gpio__port_e *port);
 void gpio__attach_interrupt(gpio__port_e port, uint32_t pin, gpio_interrupt_e interrupt_type,
@@ -13,7 +13,7 @@ void gpio__interrupt_dispatcher(void);
  * This function clears the interrupt flag for the requested port-pin
  */
 static void clear_pin_interrupt(gpio__port_e port, int interrupt_pin) {
-  fprintf(stderr, "Interrupt is cleared pin %d\n", interrupt_pin);
+  // fprintf(stderr, "Interrupt is cleared pin %d\n", interrupt_pin);
   if (GPIO__PORT_0 == port) {
     LPC_GPIOINT->IO0IntClr |= (1 << interrupt_pin);
   } else if (GPIO__PORT_2 == port) {
@@ -87,8 +87,8 @@ void gpio__interrupt_dispatcher(void) {
   const int interrupt_pin = read_pin_interrupt(&port);
   // fprintf(stderr, "Interrupt pin %d\n", interrupt_pin);
 
-  clear_pin_interrupt(port, interrupt_pin);
   function_pointer_t attached_user_handler = gpio_callbacks[interrupt_pin];
   // Invoke the user registered callback, and then clear the interrupt
   attached_user_handler();
+  clear_pin_interrupt(port, interrupt_pin);
 }

--- a/projects/lpc40xx_freertos/l3_drivers/sources/gpio_isr.c
+++ b/projects/lpc40xx_freertos/l3_drivers/sources/gpio_isr.c
@@ -1,0 +1,81 @@
+// @file gpio_isr.c
+#include "gpio_isr.h"
+
+#include "lpc40xx.h"
+#include <stdio.h>
+
+void port0pin30_isr(void);
+void port0pin29_isr(void);
+// Note: You may want another separate array for falling vs. rising edge callbacks
+static function_pointer_t gpio_callbacks[32] = {port0pin29_isr, port0pin30_isr};
+
+void gpio__attach_interrupt(gpio_port_e port, uint32_t pin, gpio_interrupt_e interrupt_type,
+                            function_pointer_t callback) {
+  gpio_callbacks[pin] = callback;
+  // 1) Store the callback based on the pin at gpio0_callbacks
+  // 2) Configure GPIO 0 pin for rising or falling edge
+  // fprintf(stderr, "Attach interrupt\n");
+  gpio_s port_pin = gpio__construct(port, pin);
+  gpio__set_as_input(port_pin);
+  if (GPIO_INTR__RISING_EDGE == interrupt_type) {
+    // fprintf(stderr, "Rising edge");
+    if (PORT0 == port) {
+      LPC_GPIOINT->IO0IntEnR |= (1 << pin);
+    } else if (PORT2 == port) {
+      LPC_GPIOINT->IO2IntEnR |= (1 << pin);
+    }
+
+  } else if (GPIO_INTR__FALLING_EDGE == interrupt_type) {
+    // fprintf(stderr, "Falling edge");
+    if (PORT0 == port) {
+      LPC_GPIOINT->IO0IntEnF |= (1 << pin);
+    } else if (PORT2 == port) {
+      LPC_GPIOINT->IO2IntEnF |= (1 << pin);
+    }
+  } else {
+  }
+}
+
+// We wrote some of the implementation for you
+void gpio__interrupt_dispatcher(void) {
+  u_int8_t port;
+  // Check which pin generated the interrupt
+  const int pin_that_generated_interrupt = logic_that_you_will_write(&port);
+  // fprintf(stderr, "Interrupt pin %d\n", pin_that_generated_interrupt);
+
+  clear_pin_interrupt(port, pin_that_generated_interrupt);
+  function_pointer_t attached_user_handler = gpio_callbacks[pin_that_generated_interrupt];
+  // Invoke the user registered callback, and then clear the interrupt
+  attached_user_handler();
+}
+
+void clear_pin_interrupt(u_int8_t port, int pin_that_generated_interrupt) {
+  // fprintf(stderr, "Interrupt is cleared pin %d\n", pin_that_generated_interrupt);
+  if (PORT0 == port) {
+    LPC_GPIOINT->IO0IntClr |= (1 << pin_that_generated_interrupt);
+  } else if (PORT2 == port) {
+    LPC_GPIOINT->IO2IntClr |= (1 << pin_that_generated_interrupt);
+  } else {
+  }
+}
+
+int logic_that_you_will_write(u_int8_t *port) {
+  int interrupt_pin = 0;
+  u_int8_t pin_num = 1;
+  uint32_t pin;
+  for (pin_num = 1; pin_num < 33; pin_num++) {
+    pin = (1 << pin_num);
+    if ((LPC_GPIOINT->IO0IntStatR & pin) || (LPC_GPIOINT->IO0IntStatF & pin)) {
+      *port = PORT0;
+      interrupt_pin = pin_num;
+      // fprintf(stderr, "Port0Pin_num = %d\n", pin_num);
+      pin_num = 33;
+    } else if ((LPC_GPIOINT->IO2IntStatR & pin) || (LPC_GPIOINT->IO2IntStatF & pin)) {
+      *port = PORT2;
+      interrupt_pin = pin_num;
+      pin_num = 33;
+    } else {
+    }
+  }
+  return interrupt_pin;
+}

--- a/projects/lpc40xx_freertos/l3_drivers/sources/gpio_isr.c
+++ b/projects/lpc40xx_freertos/l3_drivers/sources/gpio_isr.c
@@ -13,7 +13,7 @@ void gpio__interrupt_dispatcher(void);
  * This function clears the interrupt flag for the requested port-pin
  */
 static void clear_pin_interrupt(gpio__port_e port, int interrupt_pin) {
-  // fprintf(stderr, "Interrupt is cleared pin %d\n", pin_that_generated_interrupt);
+  fprintf(stderr, "Interrupt is cleared pin %d\n", interrupt_pin);
   if (GPIO__PORT_0 == port) {
     LPC_GPIOINT->IO0IntClr |= (1 << interrupt_pin);
   } else if (GPIO__PORT_2 == port) {

--- a/projects/lpc40xx_freertos/l5_application/main.c
+++ b/projects/lpc40xx_freertos/l5_application/main.c
@@ -37,7 +37,7 @@ static SemaphoreHandle_t switch_pressed_flashy;
  * user defined function
  */
 void user_isr(void) {
-  fprintf(stderr, "Interrupt is hit 30\n");
+  // fprintf(stderr, "Interrupt is hit 30\n");
   xSemaphoreGiveFromISR(switch_pressed_flashy, NULL);
 }
 /*************************************************************************************
@@ -154,7 +154,7 @@ int main(void) {
   NVIC_EnableIRQ(GPIO_IRQn); // Enable interrupt gate for the GPIO
 
   xTaskCreate(sleep_on_sem_task, "sem", (512U * 4) / sizeof(void *), (void *)&port1_led8, PRIORITY_LOW, NULL);
-  xTaskCreate(sleep_on_flashy_task, "sem", (512U * 4) / sizeof(void *), (void *)&flashy_led, PRIORITY_LOW, NULL);
+  xTaskCreate(sleep_on_flashy_task, "sem_flash", (512U * 4) / sizeof(void *), (void *)&flashy_led, PRIORITY_LOW, NULL);
 #ifdef PART0
   gpio_s port0_pin29 = gpio__construct(GPIO__PORT_0, 29);
   gpio_s port1_pin8 = gpio__construct(GPIO__PORT_1, 8);

--- a/projects/lpc40xx_freertos/l5_application/main.c
+++ b/projects/lpc40xx_freertos/l5_application/main.c
@@ -47,8 +47,7 @@ void sem_isr(void) {
   // fprintf(stderr, "Interrupt is hit 29\n");
   xSemaphoreGiveFromISR(switch_pressed_signal, NULL);
 }
-
-/****************** PART1:Interrupt with Binary Semaphore ****************************
+#ifdef PART1
 void gpio_interrupt(void);
 static void clear_gpio_interrupt(void);
 static void configure_your_gpio_interrupt(void);
@@ -61,7 +60,7 @@ void gpio_interrupt(void) {
   xSemaphoreGiveFromISR(switch_pressed_signal, NULL);
 
   // fprintf(stderr, "Interrupt is hit\n");
-  ****************** PART0:SimpleInterrupt *******************************************
+#ifdef PART0
   gpio_s port1_pin8 = gpio__construct(GPIO__PORT_1, 8);
   gpio__set_as_output(port1_pin8);
   // a) Clear Port0/2 interrupt using CLR0 or CLR2 registers
@@ -69,7 +68,7 @@ void gpio_interrupt(void) {
   // b) Use fprintf(stderr) or blink and LED here to test your ISR
   // fprintf(stderr, "Interrupt is hit");
   gpio__reset(port1_pin8);
-  ****************** PART0:SimpleInterrupt End*******************************************
+#endif
 }
 static void clear_gpio_interrupt(void) { LPC_GPIOINT->IO0IntClr |= (1 << 29); }
 static void configure_your_gpio_interrupt(void) {
@@ -77,7 +76,7 @@ static void configure_your_gpio_interrupt(void) {
   gpio__set_as_input(port0_pin29);
   LPC_GPIOINT->IO0IntEnR |= (1 << 29);
 }
-****************** PART1:Interrupt with Binary Semaphore End****************************/
+#endif
 /*************************************************************************************
  * This function is activated after port0pin29_isr provides shared resource
  */
@@ -148,15 +147,15 @@ int main(void) {
 
   lpc_peripheral__enable_interrupt(LPC_PERIPHERAL__GPIO, gpio__interrupt_dispatcher, "gpio_intr");
 
-  /****************** PART1:Interrupt with Binary Semaphore ****************************
+#ifdef PART1
   lpc_peripheral__enable_interrupt(LPC_PERIPHERAL__GPIO, gpio_interrupt, "gpio_intr");
-   configure_your_gpio_interrupt(); // TODO: Setup interrupt by re-using code from Part 0
-   ****************** PART1:Interrupt with Binary Semaphore ****************************/
+  configure_your_gpio_interrupt(); // TODO: Setup interrupt by re-using code from Part 0
+#endif
   NVIC_EnableIRQ(GPIO_IRQn); // Enable interrupt gate for the GPIO
 
   xTaskCreate(sleep_on_sem_task, "sem", (512U * 4) / sizeof(void *), (void *)&port1_led8, PRIORITY_LOW, NULL);
   xTaskCreate(sleep_on_flashy_task, "sem", (512U * 4) / sizeof(void *), (void *)&flashy_led, PRIORITY_LOW, NULL);
-  /****************** PART0:SimpleInterrupt *******************************************
+#ifdef PART0
   gpio_s port0_pin29 = gpio__construct(GPIO__PORT_0, 29);
   gpio_s port1_pin8 = gpio__construct(GPIO__PORT_1, 8);
   gpio__set_as_output(port1_pin8);
@@ -171,8 +170,8 @@ int main(void) {
   //    Hint: You can declare 'void gpio_interrupt(void)' at interrupt_vector_table.c such that it can see this
   function
 
-  // Most important step: Enable the GPIO interrupt exception using the ARM Cortex M API (this is from lpc40xx.h)
-  NVIC_EnableIRQ(GPIO_IRQn);
+      // Most important step: Enable the GPIO interrupt exception using the ARM Cortex M API (this is from lpc40xx.h)
+      NVIC_EnableIRQ(GPIO_IRQn);
 
   // Toggle an LED in a loop to ensure/test that the interrupt is entering ane exiting
   // For example, if the GPIO interrupt gets stuck, this LED will stop blinking
@@ -181,7 +180,7 @@ int main(void) {
     // TODO: Toggle an LED here
     gpio__set(port1_pin8);
   }
-  ****************** PART0:SimpleInterrupt End *******************************************/
+#endif
 
   puts("Starting RTOS");
   vTaskStartScheduler(); // This function never returns unless RTOS scheduler runs out of memory and fails


### PR DESCRIPTION
SID:014529138
LAB4-Interrupt and Binary Semaphores

Part0 and Part1 are commented in the code. Part2 is extended for extra functionalities.
The lab serves ISR - Binary semaphore usage as well as ISR - user-defined callback usage.
The lab supports multi-port interrupt functionality.